### PR TITLE
feat: add a focused editor mode

### DIFF
--- a/src/components/DraggableTrackList.tsx
+++ b/src/components/DraggableTrackList.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import { useDragAndDropReorder } from "@/hooks/useDragAndDropReorder";
+
+interface DraggableTrackListProps<T> {
+  items: T[];
+  getItemId: (item: T, index: number) => string;
+  onReorder: (items: T[]) => void;
+  renderItem: (item: T, options: { rowProps: React.HTMLAttributes<HTMLDivElement>; isDragging: boolean }) => ReactNode;
+}
+
+export function DraggableTrackList<T>({
+  items,
+  getItemId,
+  onReorder,
+  renderItem,
+}: DraggableTrackListProps<T>) {
+  const { draggedIndex, getRowProps } = useDragAndDropReorder({
+    items,
+    onReorder,
+  });
+
+  return (
+    <div className="divide-y divide-app-border">
+      {items.map((item, index) => {
+        const rowProps = getRowProps(index);
+        const isDragging = draggedIndex === index;
+        return (
+          <div key={getItemId(item, index)}>
+            {renderItem(item, { rowProps, isDragging })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+

--- a/src/components/LibraryBrowser.tsx
+++ b/src/components/LibraryBrowser.tsx
@@ -285,9 +285,7 @@ export function LibraryBrowser({ refreshTrigger }: LibraryBrowserProps) {
 
     // Check if we already have sample result cached
     if (hasSampleResult(trackFileId)) {
-      const sampleResult = getSampleResult(trackFileId)!;
-      // Start playing immediately
-      setPlayingTrack(trackFileId);
+      // Start playing immediately without updating UI until play event fires
       // Use retry logic to ensure audio element is ready
       const attemptPlay = async (attempts = 0) => {
         if (attempts > 10) return; // Max 10 attempts (1 second total)
@@ -320,9 +318,8 @@ export function LibraryBrowser({ refreshTrigger }: LibraryBrowserProps) {
     try {
       const sampleResult = await searchTrackSample(trackInfo);
       if (sampleResult) {
-        // Set sample result and playing track state first
+        // Set sample result before attempting to play
         setSampleResult(trackFileId, sampleResult);
-        setPlayingTrack(trackFileId);
         // Clear searching state AFTER setting sample result to ensure audio element exists
         setSearchingTrack(null);
         

--- a/src/components/MultiCriteriaTrackSearch.tsx
+++ b/src/components/MultiCriteriaTrackSearch.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { TrackRecord } from "@/db/schema";
+import type { LLMConfig } from "@/types/playlist";
+import { searchTracksByCriteria, type TrackSearchType } from "@/lib/track-search-engine";
+import { InlineAudioPlayer, type InlineAudioPlayerRef } from "./InlineAudioPlayer";
+import { useAudioPreviewState } from "@/hooks/useAudioPreviewState";
+import { searchTrackSample } from "@/features/audio-preview/platform-searcher";
+import { Play, Pause, Loader2, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface MultiCriteriaTrackSearchProps {
+  libraryRootId?: string;
+  llmConfig?: LLMConfig;
+  onSelectTrack: (track: TrackRecord) => void;
+}
+
+const SEARCH_TYPES: Array<{ value: TrackSearchType; label: string; placeholder: string }> = [
+  { value: "track", label: "Track", placeholder: "Search track name..." },
+  { value: "artist", label: "Artist", placeholder: "Search artist..." },
+  { value: "album", label: "Album", placeholder: "Search album..." },
+  { value: "genre", label: "Genre", placeholder: "Search genre..." },
+  { value: "tempo", label: "Tempo", placeholder: "Search tempo (slow, medium, fast, 120)" },
+  { value: "mood", label: "Mood", placeholder: "Search mood (happy, calm, energetic)" },
+];
+
+export function MultiCriteriaTrackSearch({
+  libraryRootId,
+  llmConfig,
+  onSelectTrack,
+}: MultiCriteriaTrackSearchProps) {
+  const [query, setQuery] = useState("");
+  const [searchType, setSearchType] = useState<TrackSearchType>("track");
+  const [results, setResults] = useState<TrackRecord[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const audioPreviewState = useAudioPreviewState();
+  const {
+    playingTrackId,
+    searchingTrackId,
+    getSampleResult,
+    hasSampleResult,
+    setSampleResult,
+    setError: setTrackError,
+    setPlayingTrack,
+    clearPlayingTrack,
+    setSearchingTrack,
+  } = audioPreviewState;
+
+  const audioRefs = useRef<Map<string, InlineAudioPlayerRef>>(new Map());
+
+  const searchPlaceholder = useMemo(
+    () => SEARCH_TYPES.find((type) => type.value === searchType)?.placeholder || "Search...",
+    [searchType]
+  );
+
+  useEffect(() => {
+    if (!query.trim()) {
+      setResults([]);
+      setError(null);
+      return;
+    }
+
+    const timeout = setTimeout(async () => {
+      setIsSearching(true);
+      setError(null);
+      try {
+        const tracks = await searchTracksByCriteria({
+          query,
+          type: searchType,
+          limit: 25,
+          libraryRootId,
+          llmConfig,
+        });
+        setResults(tracks);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Search failed");
+        setResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    }, 250);
+
+    return () => clearTimeout(timeout);
+  }, [query, searchType, libraryRootId, llmConfig]);
+
+  const handlePlayClick = async (track: TrackRecord) => {
+    const trackFileId = track.trackFileId;
+    if (playingTrackId === trackFileId) {
+      const audioControls = audioRefs.current.get(trackFileId);
+      if (audioControls) {
+        audioControls.pause();
+      }
+      clearPlayingTrack();
+      return;
+    }
+
+    if (playingTrackId) {
+      const prevAudioControls = audioRefs.current.get(playingTrackId);
+      if (prevAudioControls) {
+        prevAudioControls.stop();
+      }
+      clearPlayingTrack();
+    }
+
+    if (hasSampleResult(trackFileId)) {
+      setTimeout(() => {
+        const audioControls = audioRefs.current.get(trackFileId);
+        audioControls?.play();
+      }, 100);
+      return;
+    }
+
+    setSearchingTrack(trackFileId);
+    try {
+      const sampleResult = await searchTrackSample({
+        title: track.tags.title || "Unknown Title",
+        artist: track.tags.artist || "Unknown Artist",
+        album: track.tags.album,
+      });
+      if (sampleResult) {
+        setSampleResult(trackFileId, sampleResult);
+        setSearchingTrack(null);
+        setTimeout(() => {
+          const audioControls = audioRefs.current.get(trackFileId);
+          audioControls?.play();
+        }, 100);
+      } else {
+        setTrackError(trackFileId, "Preview not available for this track");
+        setSearchingTrack(null);
+      }
+    } catch (err) {
+      setTrackError(trackFileId, "Failed to find preview for this track");
+      setSearchingTrack(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col md:flex-row gap-3">
+        <select
+          value={searchType}
+          onChange={(event) => setSearchType(event.target.value as TrackSearchType)}
+          className="px-3 py-2 bg-app-hover text-app-primary rounded-sm border border-app-border focus:outline-none focus:border-accent-primary text-sm"
+        >
+          {SEARCH_TYPES.map((type) => (
+            <option key={type.value} value={type.value}>
+              {type.label}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={searchPlaceholder}
+          className="flex-1 px-4 py-2 bg-app-hover text-app-primary rounded-sm border border-app-border focus:outline-none focus:border-accent-primary text-sm"
+        />
+      </div>
+
+      {isSearching && (
+        <div className="flex items-center gap-2 text-app-secondary text-sm">
+          <Loader2 className="size-4 animate-spin" />
+          Searching...
+        </div>
+      )}
+
+      {error && <div className="text-red-500 text-sm">{error}</div>}
+
+      {!isSearching && results.length === 0 && query.trim() && (
+        <div className="text-app-tertiary text-sm">No matches found.</div>
+      )}
+
+      <div className="space-y-2 max-h-[400px] overflow-y-auto">
+        {results.map((track) => (
+          <div
+            key={track.trackFileId}
+            className="flex items-start gap-3 p-3 bg-app-hover rounded-sm border border-app-border"
+          >
+            <button
+              onClick={() => handlePlayClick(track)}
+              disabled={searchingTrackId === track.trackFileId}
+              className="flex items-center justify-center size-8 text-app-tertiary hover:text-accent-primary transition-colors shrink-0"
+            >
+              {searchingTrackId === track.trackFileId ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : playingTrackId === track.trackFileId ? (
+                <Pause className="size-4" />
+              ) : (
+                <Play className="size-4" />
+              )}
+            </button>
+
+            <div className="flex-1 min-w-0">
+              <div className="text-app-primary font-medium truncate">
+                {track.tags.title || "Unknown Title"}
+              </div>
+              <div className="text-app-secondary text-sm truncate">
+                {track.tags.artist || "Unknown Artist"}
+              </div>
+              {track.tags.album && (
+                <div className="text-app-tertiary text-xs truncate mt-1">
+                  {track.tags.album}
+                </div>
+              )}
+              {track.tags.genres.length > 0 && (
+                <div className="text-app-tertiary text-xs mt-1 truncate">
+                  {track.tags.genres.join(", ")}
+                </div>
+              )}
+            </div>
+
+            <button
+              onClick={() => onSelectTrack(track)}
+              className={cn(
+                "flex items-center gap-1 px-3 py-1.5 bg-accent-primary text-white rounded-sm text-xs transition-colors",
+                "hover:bg-accent-hover"
+              )}
+            >
+              <Plus className="size-3" />
+              Add
+            </button>
+
+            <InlineAudioPlayer
+              ref={(ref) => {
+                if (ref) {
+                  audioRefs.current.set(track.trackFileId, ref);
+                } else {
+                  audioRefs.current.delete(track.trackFileId);
+                }
+              }}
+              trackFileId={track.trackFileId}
+              sampleResult={getSampleResult(track.trackFileId) || null}
+              autoPlay={playingTrackId === track.trackFileId && !searchingTrackId && hasSampleResult(track.trackFileId)}
+              onPlay={() => setPlayingTrack(track.trackFileId)}
+              onPause={() => clearPlayingTrack()}
+              onEnded={() => clearPlayingTrack()}
+              onError={(error) => {
+                setTrackError(track.trackFileId, error);
+                clearPlayingTrack();
+              }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/SavePlaylistDialog.tsx
+++ b/src/components/SavePlaylistDialog.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import { Check, X } from "lucide-react";
+
+interface SavePlaylistDialogProps {
+  isOpen: boolean;
+  defaultTitle: string;
+  defaultDescription?: string;
+  onClose: () => void;
+  onConfirm: (options: { mode: "override" | "remix"; title: string; description?: string }) => void;
+}
+
+export function SavePlaylistDialog({
+  isOpen,
+  defaultTitle,
+  defaultDescription,
+  onClose,
+  onConfirm,
+}: SavePlaylistDialogProps) {
+  const [mode, setMode] = useState<"override" | "remix">("override");
+  const [title, setTitle] = useState(defaultTitle);
+  const [description, setDescription] = useState(defaultDescription || "");
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setMode("override");
+    setTitle(defaultTitle);
+    setDescription(defaultDescription || "");
+  }, [isOpen, defaultTitle, defaultDescription]);
+
+  useEffect(() => {
+    if (mode === "remix" && title === defaultTitle) {
+      setTitle(`${defaultTitle} (Remix)`);
+    }
+    if (mode === "override" && title.endsWith(" (Remix)")) {
+      setTitle(defaultTitle);
+    }
+  }, [mode, title, defaultTitle]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+      <div className="w-full max-w-lg bg-app-surface rounded-sm border border-app-border shadow-2xl">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-app-border">
+          <h3 className="text-app-primary text-lg font-semibold">Save Playlist</h3>
+          <button
+            onClick={onClose}
+            className="p-2 text-app-secondary hover:text-app-primary transition-colors"
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 text-app-primary text-sm">
+              <input
+                type="radio"
+                checked={mode === "override"}
+                onChange={() => setMode("override")}
+              />
+              Save as override
+            </label>
+            <label className="flex items-center gap-2 text-app-primary text-sm">
+              <input
+                type="radio"
+                checked={mode === "remix"}
+                onChange={() => setMode("remix")}
+              />
+              Save as remixed copy
+            </label>
+          </div>
+
+          <div className="space-y-3">
+            <div>
+              <label className="text-app-tertiary text-xs uppercase tracking-wider">Title</label>
+              <input
+                type="text"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                className="w-full mt-1 px-3 py-2 bg-app-hover text-app-primary rounded-sm border border-app-border focus:outline-none focus:border-accent-primary text-sm"
+              />
+            </div>
+            <div>
+              <label className="text-app-tertiary text-xs uppercase tracking-wider">Description</label>
+              <textarea
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                rows={3}
+                className="w-full mt-1 px-3 py-2 bg-app-hover text-app-primary rounded-sm border border-app-border focus:outline-none focus:border-accent-primary text-sm"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 px-6 py-4 border-t border-app-border">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-app-hover text-app-primary rounded-sm text-sm border border-app-border hover:bg-app-surface-hover transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onConfirm({ mode, title: title.trim() || defaultTitle, description: description.trim() })}
+            className="flex items-center gap-2 px-4 py-2 bg-accent-primary text-white rounded-sm text-sm hover:bg-accent-hover transition-colors"
+          >
+            <Check className="size-4" />
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/TrackAddDialog.tsx
+++ b/src/components/TrackAddDialog.tsx
@@ -1,0 +1,50 @@
+import type { TrackRecord } from "@/db/schema";
+import type { LLMConfig } from "@/types/playlist";
+import { X } from "lucide-react";
+import { MultiCriteriaTrackSearch } from "./MultiCriteriaTrackSearch";
+
+interface TrackAddDialogProps {
+  isOpen: boolean;
+  libraryRootId?: string;
+  llmConfig?: LLMConfig;
+  onAddTrack: (track: TrackRecord) => void;
+  onClose: () => void;
+}
+
+export function TrackAddDialog({
+  isOpen,
+  libraryRootId,
+  llmConfig,
+  onAddTrack,
+  onClose,
+}: TrackAddDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+      <div className="w-full max-w-3xl bg-app-surface rounded-sm border border-app-border shadow-2xl">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-app-border">
+          <h3 className="text-app-primary text-lg font-semibold">Add Track</h3>
+          <button
+            onClick={onClose}
+            className="p-2 text-app-secondary hover:text-app-primary transition-colors"
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <div className="p-6">
+          <MultiCriteriaTrackSearch
+            libraryRootId={libraryRootId}
+            llmConfig={llmConfig}
+            onSelectTrack={(track) => {
+              onAddTrack(track);
+              onClose();
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/TrackExpansionPanel.tsx
+++ b/src/components/TrackExpansionPanel.tsx
@@ -1,0 +1,127 @@
+import type { TrackRecord } from "@/db/schema";
+import { Plus } from "lucide-react";
+
+interface TrackExpansionPanelProps {
+  track: TrackRecord;
+  similarArtists: string[];
+  similarTracks: TrackRecord[];
+  onAddTrack?: (track: TrackRecord) => void;
+}
+
+function formatDuration(seconds?: number): string {
+  if (!seconds || Number.isNaN(seconds)) return "0:00";
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60);
+  return `${minutes}:${String(secs).padStart(2, "0")}`;
+}
+
+export function TrackExpansionPanel({
+  track,
+  similarArtists,
+  similarTracks,
+  onAddTrack,
+}: TrackExpansionPanelProps) {
+  const tech = track.tech || {};
+
+  return (
+    <div className="mt-3 p-4 bg-app-hover rounded-sm border border-app-border">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+        <div>
+          <div className="text-app-tertiary text-xs uppercase tracking-wider mb-2">Track Metadata</div>
+          <div className="space-y-1 text-app-secondary">
+            <div>
+              <span className="text-app-tertiary">Title:</span> {track.tags.title || "Unknown Title"}
+            </div>
+            <div>
+              <span className="text-app-tertiary">Artist:</span> {track.tags.artist || "Unknown Artist"}
+            </div>
+            <div>
+              <span className="text-app-tertiary">Album:</span> {track.tags.album || "Unknown Album"}
+            </div>
+            <div>
+              <span className="text-app-tertiary">Genres:</span>{" "}
+              {track.tags.genres.length > 0 ? track.tags.genres.join(", ") : "Unknown"}
+            </div>
+            <div>
+              <span className="text-app-tertiary">Year:</span> {track.tags.year || "Unknown"}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-app-tertiary text-xs uppercase tracking-wider mb-2">Audio Details</div>
+          <div className="space-y-1 text-app-secondary">
+            <div>
+              <span className="text-app-tertiary">Duration:</span> {formatDuration(tech.durationSeconds)}
+            </div>
+            <div>
+              <span className="text-app-tertiary">BPM:</span> {tech.bpm || "Unknown"}
+            </div>
+            <div>
+              <span className="text-app-tertiary">Bitrate:</span> {tech.bitrate ? `${tech.bitrate} kbps` : "Unknown"}
+            </div>
+            <div>
+              <span className="text-app-tertiary">Sample Rate:</span> {tech.sampleRate || "Unknown"}
+            </div>
+            <div>
+              <span className="text-app-tertiary">Channels:</span> {tech.channels || "Unknown"}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="text-app-tertiary text-xs uppercase tracking-wider mb-2">Similar Artists</div>
+        {similarArtists.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {similarArtists.map((artist) => (
+              <span
+                key={artist}
+                className="px-2 py-1 text-xs bg-app-surface text-app-primary rounded-sm border border-app-border"
+              >
+                {artist}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <div className="text-app-tertiary text-sm">No similar artists found.</div>
+        )}
+      </div>
+
+      <div className="mt-4">
+        <div className="text-app-tertiary text-xs uppercase tracking-wider mb-2">Similar Tracks</div>
+        {similarTracks.length > 0 ? (
+          <div className="space-y-2">
+            {similarTracks.map((similar) => (
+              <div
+                key={similar.trackFileId}
+                className="flex items-center justify-between gap-3 p-2 bg-app-surface rounded-sm border border-app-border"
+              >
+                <div className="min-w-0">
+                  <div className="text-app-primary text-sm truncate">
+                    {similar.tags.title || "Unknown Title"}
+                  </div>
+                  <div className="text-app-secondary text-xs truncate">
+                    {similar.tags.artist || "Unknown Artist"}
+                  </div>
+                </div>
+                {onAddTrack && (
+                  <button
+                    onClick={() => onAddTrack(similar)}
+                    className="flex items-center gap-1 px-2 py-1 text-xs bg-accent-primary text-white rounded-sm hover:bg-accent-hover transition-colors"
+                  >
+                    <Plus className="size-3" />
+                    Add
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-app-tertiary text-sm">No similar tracks found.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/db/playlist-storage.ts
+++ b/src/db/playlist-storage.ts
@@ -121,6 +121,17 @@ export async function savePlaylist(
 }
 
 /**
+ * Update an existing saved playlist with new data
+ */
+export async function updatePlaylist(
+  playlist: GeneratedPlaylist,
+  libraryRootId?: string
+): Promise<void> {
+  const record = playlistToRecord(playlist, libraryRootId);
+  await db.savedPlaylists.put(record);
+}
+
+/**
  * Get a saved playlist by ID
  */
 export async function getSavedPlaylist(id: string): Promise<GeneratedPlaylist | null> {

--- a/src/db/storage.ts
+++ b/src/db/storage.ts
@@ -76,6 +76,10 @@ export {
   getTopArtists,
   getTopAlbums,
   getTopTrackTitles,
+  searchTracksByArtist,
+  searchTracksByAlbum,
+  searchTracksByTempo,
+  searchTracksByMood,
 } from "./storage-queries";
 
 import { db } from "./schema";

--- a/src/features/library/mood-inference.ts
+++ b/src/features/library/mood-inference.ts
@@ -1,0 +1,208 @@
+import type { TrackRecord } from "@/db/schema";
+import type { LLMProvider } from "@/types/playlist";
+import { logger } from "@/lib/logger";
+import { getMoodCategories, normalizeMoodCategory } from "./mood-mapping";
+
+export interface MoodInferenceResult {
+  moods: string[];
+  confidence: number;
+  reasoning?: string;
+}
+
+async function callLLMForMood(
+  prompt: string,
+  provider: LLMProvider,
+  apiKey: string
+): Promise<string> {
+  switch (provider) {
+    case "openai":
+      return callOpenAIForMood(prompt, apiKey);
+    case "gemini":
+      return callGeminiForMood(prompt, apiKey);
+    case "claude":
+      return callClaudeForMood(prompt, apiKey);
+    case "local":
+      return callLocalLLMForMood(prompt, apiKey);
+    default:
+      throw new Error(`Unsupported LLM provider: ${provider}`);
+  }
+}
+
+async function callOpenAIForMood(prompt: string, apiKey: string): Promise<string> {
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [{ role: "user", content: prompt }],
+      response_format: { type: "json_object" },
+      temperature: 0.3,
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: { message: "Unknown error" } }));
+    throw new Error(`OpenAI API error: ${error.error?.message || response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.choices[0]?.message?.content || "";
+}
+
+async function callGeminiForMood(prompt: string, apiKey: string): Promise<string> {
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: {
+          temperature: 0.3,
+          responseMimeType: "application/json",
+        },
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: { message: "Unknown error" } }));
+    throw new Error(`Gemini API error: ${error.error?.message || response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.candidates?.[0]?.content?.parts?.[0]?.text || "";
+}
+
+async function callClaudeForMood(prompt: string, apiKey: string): Promise<string> {
+  const response = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "claude-3-haiku-20240307",
+      max_tokens: 2048,
+      messages: [{ role: "user", content: prompt }],
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: { message: "Unknown error" } }));
+    throw new Error(`Claude API error: ${error.error?.message || response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.content?.[0]?.text || "";
+}
+
+async function callLocalLLMForMood(prompt: string, apiKey: string): Promise<string> {
+  const baseUrl = apiKey.startsWith("http") ? apiKey : `http://localhost:11434`;
+  const endpoint = apiKey.startsWith("http")
+    ? `${apiKey}/api/generate`
+    : `${baseUrl}/api/generate`;
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "llama2",
+      prompt: prompt,
+      stream: false,
+      format: "json",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Local LLM API error: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.response || "";
+}
+
+function extractJSON(response: string): string {
+  const jsonMatch = response.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+  if (jsonMatch) {
+    return jsonMatch[1].trim();
+  }
+
+  const jsonObjectMatch = response.match(/\{[\s\S]*\}/);
+  if (jsonObjectMatch) {
+    return jsonObjectMatch[0];
+  }
+
+  return response.trim();
+}
+
+function buildMoodPrompt(track: TrackRecord): string {
+  const categories = getMoodCategories().join(", ");
+  const bpm = track.tech?.bpm ? `${track.tech.bpm} BPM` : "Unknown";
+  const genres = track.tags.genres.length > 0 ? track.tags.genres.join(", ") : "Unknown";
+
+  return `Given the track metadata below, classify the mood into one or more of the following categories:
+${categories}
+
+Track: "${track.tags.title}" by ${track.tags.artist}
+Album: ${track.tags.album}
+Genres: ${genres}
+Tempo: ${bpm}
+Year: ${track.tags.year || "Unknown"}
+
+Return ONLY a JSON object:
+{
+  "moods": string[] (use only the provided categories),
+  "confidence": number (0-1),
+  "reasoning": string (brief explanation)
+}`;
+}
+
+export async function inferTrackMoodWithLLM(
+  track: TrackRecord,
+  provider: LLMProvider,
+  apiKey: string,
+  timeout: number = 15000
+): Promise<MoodInferenceResult | null> {
+  try {
+    const prompt = buildMoodPrompt(track);
+    const responsePromise = callLLMForMood(prompt, provider, apiKey);
+    const timeoutPromise = new Promise<string>((_, reject) =>
+      setTimeout(() => reject(new Error("Mood inference timeout")), timeout)
+    );
+
+    const response = await Promise.race([responsePromise, timeoutPromise]);
+    const jsonStr = extractJSON(response);
+    const parsed = JSON.parse(jsonStr);
+
+    if (!Array.isArray(parsed.moods)) {
+      return null;
+    }
+
+    const normalized = parsed.moods
+      .map((m: string) => normalizeMoodCategory(String(m)))
+      .filter((m: string | null): m is string => !!m);
+
+    if (normalized.length === 0) {
+      return null;
+    }
+
+    return {
+      moods: Array.from(new Set(normalized)),
+      confidence: typeof parsed.confidence === "number" ? parsed.confidence : 0.5,
+      reasoning: typeof parsed.reasoning === "string" ? parsed.reasoning : undefined,
+    };
+  } catch (error) {
+    logger.warn(`Failed to infer mood for track ${track.trackFileId}:`, error);
+    return null;
+  }
+}
+

--- a/src/features/library/mood-mapping.ts
+++ b/src/features/library/mood-mapping.ts
@@ -1,0 +1,65 @@
+const MOOD_CATEGORIES = [
+  "Happy",
+  "Energetic",
+  "Relaxed",
+  "Melancholic",
+  "Upbeat",
+  "Calm",
+  "Intense",
+  "Peaceful",
+  "Exciting",
+  "Mellow",
+];
+
+const MOOD_SYNONYMS: Array<{ category: string; keywords: string[] }> = [
+  { category: "Happy", keywords: ["happy", "joy", "joyful", "cheerful", "bright", "sunny"] },
+  { category: "Energetic", keywords: ["energetic", "energy", "power", "driving", "high-energy"] },
+  { category: "Relaxed", keywords: ["relaxed", "relaxing", "laid-back", "easygoing", "smooth"] },
+  { category: "Melancholic", keywords: ["melancholic", "sad", "somber", "blue", "moody", "wistful"] },
+  { category: "Upbeat", keywords: ["upbeat", "bouncy", "feel-good", "positive"] },
+  { category: "Calm", keywords: ["calm", "chill", "ambient", "soft", "gentle"] },
+  { category: "Intense", keywords: ["intense", "aggressive", "heavy", "hard", "fierce"] },
+  { category: "Peaceful", keywords: ["peaceful", "tranquil", "serene", "soothing"] },
+  { category: "Exciting", keywords: ["exciting", "thrilling", "euphoric", "anthemic"] },
+  { category: "Mellow", keywords: ["mellow", "warm", "cozy", "dreamy", "nostalgic"] },
+];
+
+function normalizeTag(tag: string): string {
+  return tag.toLowerCase().trim();
+}
+
+export function getMoodCategories(): string[] {
+  return [...MOOD_CATEGORIES];
+}
+
+export function mapMoodTagsToCategories(tags: string[]): string[] {
+  if (!tags || tags.length === 0) return [];
+
+  const mapped = new Set<string>();
+  for (const raw of tags) {
+    const normalized = normalizeTag(raw);
+    if (!normalized) continue;
+
+    for (const { category, keywords } of MOOD_SYNONYMS) {
+      if (keywords.some((keyword) => normalized.includes(keyword))) {
+        mapped.add(category);
+      }
+    }
+
+    // Direct match to existing category name
+    for (const category of MOOD_CATEGORIES) {
+      if (normalized === category.toLowerCase()) {
+        mapped.add(category);
+      }
+    }
+  }
+
+  return Array.from(mapped);
+}
+
+export function normalizeMoodCategory(value: string): string | null {
+  const normalized = value.toLowerCase().trim();
+  const match = MOOD_CATEGORIES.find((category) => category.toLowerCase() === normalized);
+  return match || null;
+}
+

--- a/src/hooks/useDragAndDropReorder.ts
+++ b/src/hooks/useDragAndDropReorder.ts
@@ -1,0 +1,72 @@
+import { useCallback, useState } from "react";
+
+interface DragAndDropOptions<T> {
+  items: T[];
+  onReorder: (items: T[]) => void;
+}
+
+function reorderItems<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+  const next = [...items];
+  const [moved] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, moved);
+  return next;
+}
+
+export function useDragAndDropReorder<T>({ items, onReorder }: DragAndDropOptions<T>) {
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+
+  const handleDragStart = useCallback(
+    (index: number) => (event: React.DragEvent) => {
+      setDraggedIndex(index);
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("text/plain", String(index));
+    },
+    []
+  );
+
+  const handleDragOver = useCallback(
+    (index: number) => (event: React.DragEvent) => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "move";
+      if (draggedIndex === null || draggedIndex === index) {
+        return;
+      }
+    },
+    [draggedIndex]
+  );
+
+  const handleDrop = useCallback(
+    (index: number) => (event: React.DragEvent) => {
+      event.preventDefault();
+      if (draggedIndex === null || draggedIndex === index) {
+        setDraggedIndex(null);
+        return;
+      }
+      const reordered = reorderItems(items, draggedIndex, index);
+      onReorder(reordered);
+      setDraggedIndex(null);
+    },
+    [draggedIndex, items, onReorder]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggedIndex(null);
+  }, []);
+
+  const getRowProps = useCallback(
+    (index: number) => ({
+      draggable: true,
+      onDragStart: handleDragStart(index),
+      onDragOver: handleDragOver(index),
+      onDrop: handleDrop(index),
+      onDragEnd: handleDragEnd,
+    }),
+    [handleDragEnd, handleDragOver, handleDragStart, handleDrop]
+  );
+
+  return {
+    draggedIndex,
+    getRowProps,
+  };
+}
+

--- a/src/hooks/usePlaylistEditState.ts
+++ b/src/hooks/usePlaylistEditState.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from "react";
+import type { GeneratedPlaylist } from "@/features/playlists";
+import type { PlaylistSummary } from "@/features/playlists";
+
+interface EditStateOptions {
+  buildSummary: (trackFileIds: string[]) => PlaylistSummary;
+}
+
+export function usePlaylistEditState(
+  playlist: GeneratedPlaylist,
+  { buildSummary }: EditStateOptions
+) {
+  const [editedPlaylist, setEditedPlaylist] = useState<GeneratedPlaylist>(playlist);
+  const [isDirty, setIsDirty] = useState(false);
+
+  useEffect(() => {
+    setEditedPlaylist(playlist);
+    setIsDirty(false);
+  }, [playlist]);
+
+  useEffect(() => {
+    const summary = buildSummary(editedPlaylist.trackFileIds);
+    setEditedPlaylist((prev) => ({
+      ...prev,
+      summary,
+      totalDuration: summary.totalDuration,
+    }));
+  }, [buildSummary, editedPlaylist.trackFileIds]);
+
+  const updateTrackFileIds = useCallback(
+    (trackFileIds: string[]) => {
+      const summary = buildSummary(trackFileIds);
+      setEditedPlaylist((prev) => ({
+        ...prev,
+        trackFileIds,
+        summary,
+        totalDuration: summary.totalDuration,
+      }));
+      setIsDirty(true);
+    },
+    [buildSummary]
+  );
+
+  const updatePlaylist = useCallback((updater: (prev: GeneratedPlaylist) => GeneratedPlaylist) => {
+    setEditedPlaylist((prev) => {
+      const next = updater(prev);
+      const summary = buildSummary(next.trackFileIds);
+      return {
+        ...next,
+        summary,
+        totalDuration: summary.totalDuration,
+      };
+    });
+    setIsDirty(true);
+  }, [buildSummary]);
+
+  const resetEdits = useCallback(() => {
+    setEditedPlaylist(playlist);
+    setIsDirty(false);
+  }, [playlist]);
+
+  const markClean = useCallback((next: GeneratedPlaylist) => {
+    setEditedPlaylist(next);
+    setIsDirty(false);
+  }, []);
+
+  return {
+    editedPlaylist,
+    isDirty,
+    setEditedPlaylist,
+    updateTrackFileIds,
+    updatePlaylist,
+    resetEdits,
+    markClean,
+  };
+}
+

--- a/src/lib/playlist-summary-calculator.ts
+++ b/src/lib/playlist-summary-calculator.ts
@@ -1,0 +1,66 @@
+import type { PlaylistSummary } from "@/features/playlists";
+
+export interface SummaryTrackInput {
+  trackFileId: string;
+  genres: string[];
+  artist?: string;
+  durationSeconds?: number;
+  bpm?: number;
+}
+
+type TempoBucket = "slow" | "medium" | "fast" | "unknown";
+
+function getTempoBucket(bpm?: number): TempoBucket {
+  if (typeof bpm !== "number" || Number.isNaN(bpm)) {
+    return "unknown";
+  }
+  if (bpm < 90) return "slow";
+  if (bpm < 140) return "medium";
+  return "fast";
+}
+
+export function calculatePlaylistSummaryFromTracks(
+  tracks: SummaryTrackInput[]
+): PlaylistSummary {
+  const genreMix = new Map<string, number>();
+  const tempoMix = new Map<string, number>();
+  const artistMix = new Map<string, number>();
+  const durations: number[] = [];
+
+  for (const track of tracks) {
+    for (const genre of track.genres) {
+      genreMix.set(genre, (genreMix.get(genre) || 0) + 1);
+    }
+
+    const tempoBucket = getTempoBucket(track.bpm);
+    tempoMix.set(tempoBucket, (tempoMix.get(tempoBucket) || 0) + 1);
+
+    const artist = track.artist || "Unknown Artist";
+    artistMix.set(artist, (artistMix.get(artist) || 0) + 1);
+
+    const duration = track.durationSeconds || 0;
+    if (duration > 0) {
+      durations.push(duration);
+    }
+  }
+
+  const totalDuration = tracks.reduce(
+    (sum, track) => sum + (track.durationSeconds || 0),
+    0
+  );
+
+  return {
+    totalDuration,
+    trackCount: tracks.length,
+    genreMix,
+    tempoMix,
+    artistMix,
+    avgDuration:
+      durations.length > 0
+        ? durations.reduce((a, b) => a + b, 0) / durations.length
+        : 0,
+    minDuration: durations.length > 0 ? Math.min(...durations) : 0,
+    maxDuration: durations.length > 0 ? Math.max(...durations) : 0,
+  };
+}
+

--- a/src/lib/similar-tracks-finder.ts
+++ b/src/lib/similar-tracks-finder.ts
@@ -1,0 +1,66 @@
+import type { TrackRecord } from "@/db/schema";
+
+export interface SimilarTracksResult {
+  similarArtists: string[];
+  similarTracks: TrackRecord[];
+}
+
+type TempoBucket = "slow" | "medium" | "fast" | "unknown";
+
+function getTempoBucket(bpm?: number): TempoBucket {
+  if (typeof bpm !== "number" || Number.isNaN(bpm)) {
+    return "unknown";
+  }
+  if (bpm < 90) return "slow";
+  if (bpm < 140) return "medium";
+  return "fast";
+}
+
+export function findSimilarTracks(
+  track: TrackRecord,
+  allTracks: TrackRecord[],
+  limit: number = 10
+): SimilarTracksResult {
+  const genreSet = new Set(track.tags.genres.map((genre) => genre.toLowerCase()));
+  const tempoBucket = getTempoBucket(track.tech?.bpm);
+  const artist = track.tags.artist?.toLowerCase() || "";
+
+  const scored = allTracks
+    .filter((candidate) => candidate.trackFileId !== track.trackFileId)
+    .map((candidate) => {
+      let score = 0;
+      if (candidate.tags.artist?.toLowerCase() === artist) {
+        score += 3;
+      }
+
+      const candidateGenres = candidate.tags.genres.map((genre) => genre.toLowerCase());
+      const genreOverlap = candidateGenres.filter((g) => genreSet.has(g)).length;
+      if (genreOverlap > 0) {
+        score += Math.min(2, genreOverlap);
+      }
+
+      const candidateTempo = getTempoBucket(candidate.tech?.bpm);
+      if (tempoBucket !== "unknown" && candidateTempo === tempoBucket) {
+        score += 1;
+      }
+
+      return { candidate, score };
+    })
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  const similarTracks = scored.slice(0, limit).map((item) => item.candidate);
+  const similarArtists = Array.from(
+    new Set(
+      similarTracks
+        .map((candidate) => candidate.tags.artist)
+        .filter((name): name is string => !!name && name.toLowerCase() !== artist)
+    )
+  ).slice(0, limit);
+
+  return {
+    similarArtists,
+    similarTracks,
+  };
+}
+

--- a/src/lib/track-search-engine.ts
+++ b/src/lib/track-search-engine.ts
@@ -1,0 +1,175 @@
+import type { TrackRecord } from "@/db/schema";
+import type { LLMConfig } from "@/types/playlist";
+import { getCompositeId } from "@/db/schema";
+import {
+  filterTracksByGenre,
+  searchTracks,
+  searchTracksByAlbum,
+  searchTracksByArtist,
+  searchTracksByMood,
+  searchTracksByTempo,
+} from "@/db/storage";
+import { getAllTracks, getTracks } from "@/db/storage";
+import { updateTrackMood } from "@/db/storage-tracks";
+import { inferTrackMoodWithLLM } from "@/features/library/mood-inference";
+import { mapMoodTagsToCategories, normalizeMoodCategory } from "@/features/library/mood-mapping";
+
+export type TrackSearchType = "track" | "artist" | "album" | "genre" | "tempo" | "mood";
+
+interface TrackSearchParams {
+  query: string;
+  type: TrackSearchType;
+  limit?: number;
+  libraryRootId?: string;
+  llmConfig?: LLMConfig;
+}
+
+const mappedMoodCache = new Map<string, string[]>();
+let moodMappingWarm = false;
+
+function warmMoodMappingCache(tracks: TrackRecord[]) {
+  if (moodMappingWarm) return;
+  moodMappingWarm = true;
+
+  setTimeout(() => {
+    for (const track of tracks) {
+      const tags = track.enhancedMetadata?.mood || [];
+      if (tags.length === 0) continue;
+      const mapped = mapMoodTagsToCategories(tags);
+      if (mapped.length > 0) {
+        mappedMoodCache.set(track.trackFileId, mapped);
+      }
+    }
+  }, 0);
+}
+
+function getMappedMoodsForTrack(track: TrackRecord): string[] {
+  const cached = mappedMoodCache.get(track.trackFileId);
+  if (cached) return cached;
+  const tags = track.enhancedMetadata?.mood || [];
+  if (tags.length === 0) return [];
+  const mapped = mapMoodTagsToCategories(tags);
+  if (mapped.length > 0) {
+    mappedMoodCache.set(track.trackFileId, mapped);
+  }
+  return mapped;
+}
+
+function parseTempoQuery(query: string): "slow" | "medium" | "fast" | { min: number; max: number } | null {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "slow" || normalized === "medium" || normalized === "fast") {
+    return normalized;
+  }
+
+  const rangeMatch = normalized.match(/^(\d+)\s*-\s*(\d+)$/);
+  if (rangeMatch) {
+    const min = Number(rangeMatch[1]);
+    const max = Number(rangeMatch[2]);
+    if (!Number.isNaN(min) && !Number.isNaN(max)) {
+      return { min, max };
+    }
+  }
+
+  const bpm = Number(normalized);
+  if (!Number.isNaN(bpm)) {
+    return { min: bpm - 5, max: bpm + 5 };
+  }
+
+  return null;
+}
+
+async function searchByMood(
+  query: string,
+  limit: number,
+  libraryRootId?: string,
+  llmConfig?: LLMConfig
+): Promise<TrackRecord[]> {
+  const normalizedMood = normalizeMoodCategory(query);
+  if (!normalizedMood) {
+    return [];
+  }
+
+  const allTracks = libraryRootId ? await getTracks(libraryRootId) : await getAllTracks();
+  warmMoodMappingCache(allTracks);
+
+  const mappedMatches: TrackRecord[] = [];
+  for (const track of allTracks) {
+    const mapped = getMappedMoodsForTrack(track);
+    if (mapped.includes(normalizedMood)) {
+      mappedMatches.push(track);
+    }
+    if (mappedMatches.length >= limit) {
+      return mappedMatches.slice(0, limit);
+    }
+  }
+
+  if (!llmConfig || !llmConfig.apiKey || !llmConfig.provider) {
+    return mappedMatches.slice(0, limit);
+  }
+
+  // If we still need more results, infer moods for tracks without mapped tags
+  const remainingSlots = limit - mappedMatches.length;
+  if (remainingSlots <= 0) {
+    return mappedMatches.slice(0, limit);
+  }
+
+  const candidates = allTracks.filter((track) => getMappedMoodsForTrack(track).length === 0);
+  for (const track of candidates) {
+    if (mappedMatches.length >= limit) break;
+
+    const inference = await inferTrackMoodWithLLM(track, llmConfig.provider, llmConfig.apiKey);
+    if (!inference || inference.moods.length === 0) {
+      continue;
+    }
+
+    const mapped = inference.moods
+      .map((mood) => normalizeMoodCategory(mood))
+      .filter((mood): mood is string => !!mood);
+
+    if (mapped.length === 0) {
+      continue;
+    }
+
+    mappedMoodCache.set(track.trackFileId, mapped);
+    if (mapped.includes(normalizedMood)) {
+      mappedMatches.push(track);
+    }
+
+    if (!track.enhancedMetadata?.mood || track.enhancedMetadata.mood.length === 0) {
+      const trackId = getCompositeId(track.trackFileId, track.libraryRootId);
+      await updateTrackMood(trackId, mapped, false);
+    }
+  }
+
+  return mappedMatches.slice(0, limit);
+}
+
+export async function searchTracksByCriteria({
+  query,
+  type,
+  limit = 25,
+  libraryRootId,
+  llmConfig,
+}: TrackSearchParams): Promise<TrackRecord[]> {
+  switch (type) {
+    case "track":
+      return searchTracks(query, libraryRootId, limit);
+    case "artist":
+      return searchTracksByArtist(query, limit, libraryRootId);
+    case "album":
+      return searchTracksByAlbum(query, limit, libraryRootId);
+    case "genre":
+      return filterTracksByGenre(query, libraryRootId, limit);
+    case "tempo": {
+      const tempoQuery = parseTempoQuery(query);
+      if (!tempoQuery) return [];
+      return searchTracksByTempo(tempoQuery, limit, libraryRootId);
+    }
+    case "mood":
+      return searchByMood(query, limit, libraryRootId, llmConfig);
+    default:
+      return [];
+  }
+}
+


### PR DESCRIPTION
Adds the ability to enter a "focus mode" with UI optimized for editing the generated playlist:
- drag and drop order of tracks
- quickly add tracks based on recommendation
- regenerate the playlist based on suggested quick edit buttons
- manually add tracks based on searching for track name, album, genre, or artist